### PR TITLE
Serenity-junit webtests update: mvn continue on fail and dependency upgrade

### DIFF
--- a/junit-webtests/pom.xml
+++ b/junit-webtests/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <serenity.version>1.1.9</serenity.version>
-        <serenity.maven.version>1.1.9</serenity.maven.version>
+        <serenity.version>1.1.25-rc.2</serenity.version>
+        <serenity.maven.version>1.1.25-rc.2</serenity.maven.version>
         <tags></tags>
     </properties>
 
@@ -84,7 +84,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
                 <configuration>
-                    <skip>true</skip>
+                    <testFailureIgnore>true</testFailureIgnore>
                 </configuration>
             </plugin>
             <plugin>
@@ -126,7 +126,7 @@
                     <dependency>
                         <groupId>net.serenity-bdd</groupId>
                         <artifactId>serenity-core</artifactId>
-                        <version>1.0.65-SNAPSHOT</version>
+                        <version>1.1.25-rc.2</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/junit-webtests/serenity.properties
+++ b/junit-webtests/serenity.properties
@@ -1,8 +1,8 @@
 webdriver.driver=phantomjs
-serenity.project.name = Demo Project using Serenity and Cucumber
-serenity.test.root=net.thucydides.showcase.junit.features
-serenity.dry.run=true
-serenity.requirement.types=feature, story
+#serenity.project.name = Demo Project using Serenity and Cucumber
+#serenity.test.root=net.thucydides.showcase.junit.features
+#serenity.dry.run=false
+#serenity.requirement.types=feature, story
 #serenity.use.unique.browser = true
 
 serenity.browser,height = 1200


### PR DESCRIPTION
#### Summary of this PR
Updates pom to continue build after test fail. Updated dependency to last (serenity-core) 
#### Intended effect
Aggregate reports now can be created with command ``` mvn clean verify```
#### How should this be manually tested?
``` mvn clean verify```
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
serenity-bdd/serenity-maven-plugin/issues/25
#### Screenshots (if appropriate)
N/A