### PR TITLE
Updated serenity and jbehave API versions

### DIFF
--- a/jbehave-webtests/pom.xml
+++ b/jbehave-webtests/pom.xml
@@ -12,17 +12,28 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <serenity.version>1.1.22-SNAPSHOT</serenity.version>
+        <serenity.version>1.1.39</serenity.version>
         <serenity.maven.version>1.1.21</serenity.maven.version>
-        <serenity.jbehave.version>1.2.1-SNAPSHOT</serenity.jbehave.version>
+        <serenity.jbehave.version>1.13.0</serenity.jbehave.version>
         <webdriver.driver>phantomjs</webdriver.driver>
     </properties>
 
     <dependencies>
         <dependency>
+          <groupId>commons-collections</groupId>
+          <artifactId>commons-collections</artifactId>
+          <version>3.2.2</version>
+        </dependency>
+        <dependency>
             <groupId>net.serenity-bdd</groupId>
             <artifactId>serenity-core</artifactId>
             <version>${serenity.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                </exclusion>
+             </exclusions>
         </dependency>
         <dependency>
             <groupId>net.serenity-bdd</groupId>
@@ -47,7 +58,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.7</version>
+            <version>1.7.21</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Changes:
1.Updated versions for serenity and JBehave APIs to current latest as versions specified in the existing POM are no more available on Maven Central
2.Fixed dependency convergence issue for sl4j api and commons-collections api
3.Tested with Maven 3.3.9 and Jdk 1.8
