### PR TITLE
Added gradle build. Run cucumber tests and generate serenity reports …

### DIFF
--- a/cucumber-webtests/build.gradle
+++ b/cucumber-webtests/build.gradle
@@ -1,0 +1,59 @@
+buildscript {
+	repositories {
+		jcenter()
+	}
+	dependencies {
+		classpath("net.serenity-bdd:serenity-gradle-plugin:1.1.1")
+	}
+}
+
+apply plugin: 'java'
+apply plugin: 'net.serenity-bdd.aggregator'
+
+def cucumberVersion = "1.2.5"
+def serenityVersion = "1.1.1"
+
+repositories {
+	jcenter()
+}
+
+configurations {
+	cucumberRuntime {
+		extendsFrom testRuntime
+	}
+}
+
+task cucumber() {
+	dependsOn assemble
+	doLast {
+		javaexec {
+			main = "cucumber.api.cli.Main"
+			classpath = configurations.cucumberRuntime
+			args = ['--plugin', 'pretty', '--glue', 'src/test/java', 'src/test/resources']
+
+		}
+	}
+}
+
+//Ensure the cucumber tests are executed as part of the build. Makes for a very pretty output.
+build.dependsOn cucumber
+
+dependencies {
+	compile "net.serenity-bdd:serenity-core:$serenityVersion"
+	compile "net.serenity-bdd:serenity-cucumber:$serenityVersion"
+	compile("net.serenity-bdd:serenity-rest-assured:$serenityVersion")
+	
+
+	cucumberRuntime files("${jar.archivePath}")
+
+	compile 'junit:junit:4.12'
+	compile "info.cukes:cucumber-junit:$cucumberVersion"
+	compile "info.cukes:cucumber-java:$cucumberVersion"
+	compile "net.serenity-bdd:serenity-junit:$serenityVersion"
+	compile('org.slf4j:slf4j-simple:1.7.12')
+	compile 'com.googlecode.lambdaj:lambdaj:2.3.3'
+	compile 'org.assertj:assertj-core:3.1.0'
+	compile 'org.codehaus.groovy:groovy-all:2.3.10'
+}
+
+gradle.startParameter.continueOnFailure = true

--- a/cucumber-webtests/serenity.properties
+++ b/cucumber-webtests/serenity.properties
@@ -1,4 +1,4 @@
-webdriver.driver=chrome
+webdriver.driver=phantomjs
 serenity.project.name = Demo Project using Serenity and Cucumber
 
 serenity.use.unique.browser = false
@@ -11,5 +11,6 @@ serenity.dry.run=false
 serenity.test.root=net.thucydides.showcase.cucumber.junit
 
 # How long does Serenity wait for elements that are not present on the screen to load
-webdriver.timeouts.implicitlywait = 5000
+webdriver.timeouts.implicitlywait = 500
 serenity.take.screenshots=AFTER_EACH_STEP
+phantomjs.binary.path=/Users/agatanoair/Desktop/phantomjs


### PR DESCRIPTION
Hi, 
I thought it would be useful to add a gradle build to this project, as it was missing one.
Since the gradle.build files in some of the other demos were not working for me (reported as issue), I thought I would share this.

…by running: gradle check aggregate. Some of the cucumber tests are failing, but they are also failing for the mvn build (because etsy behaves differently than expected)